### PR TITLE
Allow passing null userAgent.

### DIFF
--- a/src/main/java/com/optimaize/webcrawlerverifier/DefaultKnownCrawlerDetector.java
+++ b/src/main/java/com/optimaize/webcrawlerverifier/DefaultKnownCrawlerDetector.java
@@ -22,7 +22,7 @@ public class DefaultKnownCrawlerDetector implements KnownCrawlerDetector {
 
     @NotNull
     @Override
-    public Optional<KnownCrawlerResult> detect(@NotNull String userAgent, @NotNull String ip) {
+    public Optional<KnownCrawlerResult> detect(String userAgent, @NotNull String ip) {
         for (KnownHostBotVerifier verifier : verifiers) {
             BotCheckerResult check = verifier.check(userAgent, ip);
             if (check != BotCheckerResult.IS_NOT) {

--- a/src/main/java/com/optimaize/webcrawlerverifier/KnownCrawlerDetector.java
+++ b/src/main/java/com/optimaize/webcrawlerverifier/KnownCrawlerDetector.java
@@ -14,6 +14,6 @@ public interface KnownCrawlerDetector {
      * @return absent if none detected.
      */
     @NotNull
-    Optional<KnownCrawlerResult> detect(@NotNull String userAgent, @NotNull String ip);
+    Optional<KnownCrawlerResult> detect(String userAgent, @NotNull String ip);
 
 }

--- a/src/main/java/com/optimaize/webcrawlerverifier/bots/KnownHostBotVerifier.java
+++ b/src/main/java/com/optimaize/webcrawlerverifier/bots/KnownHostBotVerifier.java
@@ -35,6 +35,6 @@ public interface KnownHostBotVerifier {
      * @return
      */
     @NotNull
-    BotCheckerResult check(@NotNull String userAgent, @NotNull String ip);
+    BotCheckerResult check(String userAgent, @NotNull String ip);
 
 }

--- a/src/main/java/com/optimaize/webcrawlerverifier/bots/KnownHostBotVerifierImpl.java
+++ b/src/main/java/com/optimaize/webcrawlerverifier/bots/KnownHostBotVerifierImpl.java
@@ -8,6 +8,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 /**
  *
  */
@@ -38,8 +40,8 @@ class KnownHostBotVerifierImpl implements KnownHostBotVerifier {
 
     @Override
     @NotNull
-    public BotCheckerResult check(@NotNull String userAgent, @NotNull String ip) {
-        if (!crawlerData.getUserAgentChecker().apply(userAgent)) {
+    public BotCheckerResult check(String userAgent, @NotNull String ip) {
+        if (isNullOrEmpty(userAgent) || !crawlerData.getUserAgentChecker().apply(userAgent)) {
             return BotCheckerResult.IS_NOT;
         } else {
             Set<String> permittedIps = crawlerData.getIps();

--- a/src/test/java/com/optimaize/webcrawlerverifier/DefaultKnownCrawlerDetectorTest.java
+++ b/src/test/java/com/optimaize/webcrawlerverifier/DefaultKnownCrawlerDetectorTest.java
@@ -20,6 +20,7 @@ public class DefaultKnownCrawlerDetectorTest {
     public void none() throws Exception {
         DefaultKnownCrawlerDetector detector = all();
         assertFalse(detector.detect("", "127.0.0.1").isPresent());
+        assertFalse(detector.detect(null, "127.0.0.1").isPresent());
     }
 
     /**


### PR DESCRIPTION
Reason for the change: user agent can actually be null so allowing it will make detector usage more convenient.
Detection result will be the same as for an empty string.